### PR TITLE
Put tools back in $PATH

### DIFF
--- a/Formula/gnustep-make.rb
+++ b/Formula/gnustep-make.rb
@@ -22,10 +22,10 @@ class GnustepMake < Formula
     system "./configure", *std_configure_args,
                           "--with-config-file=#{prefix}/etc/GNUstep.conf",
                           "--enable-native-objc-exceptions"
-    system "make", "install", "tooldir=#{libexec}"
+    system "make", "install", "tooldir=#{bin}"
   end
 
   test do
-    assert_match shell_output("#{libexec}/gnustep-config --variable=CC").chomp, ENV.cc
+    assert_match shell_output("#{bin}/gnustep-config --variable=CC").chomp, ENV.cc
   end
 end


### PR DESCRIPTION
By putting gnustep-configure under libexec, it's impossible to discover any of the paths configured by this package without already knowing them. Put them back in #{bin} so they can be linked and can be found in normal $PATH search.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
